### PR TITLE
fix: remove workflow_run action trigger for release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,6 @@ on:
   push:
     tags:
       - '*'
-  workflow_run:
-    workflows:
-      - check
-    types:
-      - completed
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
Goal with ``workflow_run`` was to trigger the workflow **after** ``check`` finished. But always, only on tags.

It looks like the release.yml workflow is nonetheless triggered after merges on main, without tags 